### PR TITLE
Specify fallback avatar if given one fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,11 @@ Typical usage of `r-pagination` may look like:
   {{r-avatar src='https://cdn.catimages.com/massive-cat.jpg'}}
   ```
 
+- `fallbackSrc` - Specifies an alternate URL to use if `src` fails (e.g. returns 404).
+  ```
+  {{r-avatar src="https://example.com/404" fallbackSrc='https://cdn.catimages.com/massive-cat.jpg'}}
+  ```
+
 Typical usage of the `r-avatar` may look like:
 
 ```

--- a/addon/components/r-avatar/component.js
+++ b/addon/components/r-avatar/component.js
@@ -8,6 +8,7 @@ export default Component.extend({
   layout,
   tagName: 'img',
   classNames: ['circle'],
+  fallbackSrc: '/assets/images/avatar/dog.png',
 
   attributeBindings: ['src'],
 
@@ -36,8 +37,9 @@ export default Component.extend({
 
   didRender() {
     this._super(...arguments);
+    const that = this;
     $(".circle").on("error", function() {
-      $(this).attr('src', '/assets/images/avatar/dog.png');
+      $(this).attr('src', get(that, 'fallbackSrc'));
     })
   }
 });

--- a/tests/dummy/app/components/avatars-wrapper/template.hbs
+++ b/tests/dummy/app/components/avatars-wrapper/template.hbs
@@ -4,4 +4,5 @@
   {{r-avatar src='avatars/1.png' size="medium"}}
   {{r-avatar src='avatars/1.png' size="large"}}
   {{r-avatar src='avatars/1.png' size="x-large"}}
+  {{r-avatar src='blah' fallbackSrc='avatars/1.png' size="x-large"}}
 </div>


### PR DESCRIPTION
Today I noticed that there's no escaping the cute Science Dog when the image load fails. I thought I'd provide a way for client code to provide a different fallback image.